### PR TITLE
No longer double-skip PC increment

### DIFF
--- a/libs/chip8/src/chip8-test.zig
+++ b/libs/chip8/src/chip8-test.zig
@@ -145,7 +145,7 @@ test "0NNN Skips Machine Code Instruction" {
     interpreter.opcode = 0x0FFF;
     try interpreter.decode();
 
-    try std.testing.expectEqual(chip8.pc_init + 2, interpreter.pc);
+    try std.testing.expectEqual(chip8.pc_init, interpreter.pc);
 }
 
 test "7XNN" {

--- a/libs/chip8/src/chip8.zig
+++ b/libs/chip8/src/chip8.zig
@@ -544,12 +544,10 @@ pub const Chip8 = struct {
 
     fn unknownOpcode(self: *Chip8) void {
         std.log.warn("Encountered unknown opcode {x}. Skipping.", .{self.opcode});
-        self.pc += 2;
     }
 
     fn skipMachineCodeInstruction(self: *Chip8) void {
         std.log.warn("Encountered opcode 0{x}, which relies on executing machine-specific code. Ignoring.", .{self.opcode});
-        self.pc += 2;
     }
 
     fn skipNextInstrVxNn(self: *Chip8, if_eq: bool) void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -2,6 +2,8 @@ const std = @import("std");
 const chip8 = @import("chip8");
 const Chip8 = chip8.Chip8;
 
+const ch8_ext = ".ch8";
+
 pub fn main() anyerror!void {
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer arena.deinit();
@@ -23,19 +25,22 @@ pub fn main() anyerror!void {
     defer args_iterator.deinit();
 
     var program_path: ?([]const u8) = args_iterator.next();
+    while (!hasCh8Ext(program_path)) program_path = args_iterator.next();
 
-    if (program_path) |*path| {
-        _ = try interpreter.load(path.*);
-
-        std.debug.print("Interpeter Initialized and program loaded! \n{}\nMemory:\n{s}\n", .{ interpreter, interpreter.memory });
+    if (program_path) |path| {
+        var bytes_read = try interpreter.load(path);
+        std.debug.print("Interpeter Initialized and program loaded! {} bytes read.\n", .{bytes_read});
 
         while (true) {
             try interpreter.emulateCycle();
-            break;
         }
     } else {
         std.debug.print("Program file path not provided. Program not loaded! Exiting...", .{});
     }
+}
+
+fn hasCh8Ext(arg: ?([]const u8)) bool {
+    return if (arg) |arg_arr| std.mem.endsWith(u8, arg_arr, ch8_ext) else false;
 }
 
 test "basic test" {


### PR DESCRIPTION
- Used to over-skip opcodes when an opcode we didn't handle (unknown or machine instruction) was encountered
- Skipping the "next instruction" now constrained only to explicit opcodes communicated as doing so